### PR TITLE
Update android-nvim.lua

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+no_call_parentheses = true


### PR DESCRIPTION
added promt to select template, give project name and package name
using plenary.async for cleaner code
added .stylua.toml for consistent code styling
added initial support for using custom templates by setting vim.g.android_templates_dir = "path_to_templates_dir" or setting vim.g.android_templates = { "path_to_indivitual_template", ...}